### PR TITLE
feat: add identity verifications

### DIFF
--- a/src/App2FA.cpp
+++ b/src/App2FA.cpp
@@ -1,0 +1,37 @@
+#include "App2FA.h"
+#include "Core/utils.h"
+#include "Env.h"
+#include "Server.h"
+#include <ctime>
+#include <utility>
+using namespace std;
+
+App2FA::App2FA() : secret(0), id(-1) {}
+
+App2FA::App2FA(const string &username, Server *server) {
+  setServer(username, server);
+}
+
+App2FA::~App2FA() {}
+
+void App2FA::setServer(const string &username, Server *server) {
+  if (server) {
+    auto ret = server->setup2FA(username);
+    if (ret.first != -1) {
+      id = ret.first;      // Set the ID for the 2FA
+      secret = ret.second; // Set the secret key for the 2FA
+    } else {
+      cerr << "Failed to set up App2FA for user: " << username << endl;
+    }
+  }
+}
+
+int App2FA::generateVerificationCode() const {
+  if (secret == 0) {
+    cerr << "App2FA secret is not set." << endl;
+    return -1; // Return -1 if the secret is not set
+  }
+  // Generate a verification code based on the secret and current time
+  long long currentTime = mktime(Env::getNow().getStdTM());
+  return Utils::generateVerificationCode(secret, currentTime); // 6-digit code
+}

--- a/src/App2FA.h
+++ b/src/App2FA.h
@@ -1,0 +1,33 @@
+#ifndef APP_2FA_H
+#define APP_2FA_H
+
+#include <string>
+
+class Server;
+
+class App2FA {
+private:
+  long long secret; // Secret key for the app 2FA
+  long long id;
+
+protected:
+public:
+  App2FA();
+  App2FA(const std::string &username, Server *server);
+  virtual ~App2FA();
+  /**
+   * @brief Generate a verification code based on the app secret and current
+   * time
+   * @return Generated verification code as a string
+   */
+  int generateVerificationCode() const;
+
+  /**
+   * @brief Set server for the app 2FA
+   * @param username The username of the user
+   * @param server Pointer to the server instance
+   */
+  void setServer(const std::string &username, Server *server);
+};
+
+#endif // APP_2FA_H

--- a/src/Box.cpp
+++ b/src/Box.cpp
@@ -36,7 +36,8 @@ Card *Box::addCard(Card *card, const string &username) {
 }
 
 Card *Box::retrieveCard(const std::string &username, const std::string &cardId,
-                        const std::string &passwd, Card *paymentCard) {
+                        const std::string &passwd, int verificationCode,
+                        Card *paymentCard) {
   // Check if the user is authenticated
   if (!server->checkUser(username, passwd)) {
     return nullptr; // Authentication failed
@@ -51,7 +52,7 @@ Card *Box::retrieveCard(const std::string &username, const std::string &cardId,
     }
     paymentCard->adjustBalance(-reward); // Deduct the reward from payment card
     // Notify the server that the card is retrieved
-    if (!server->notifyCardRetrieved(cardId)) {
+    if (!server->notifyCardRetrieved(cardId, verificationCode)) {
       return nullptr; // Failed to notify the server
     }
     cards.erase(it); // Remove the card from the box

--- a/src/Box.h
+++ b/src/Box.h
@@ -34,11 +34,13 @@ public:
    * @param username: the username of the user who wants to retrieve the card
    * @param cardId: the id of the card to be retrieved
    * @param passwd: the password of the user
+   * @param verificationCode: the verification code for card retrieval
    * @param card: pointer to the card for payment
    * @return: pointer to the card if found, nullptr if not found or error occurs
    */
   Card *retrieveCard(const std::string &username, const std::string &cardId,
-                     const std::string &passwd, Card *card = nullptr);
+                     const std::string &passwd, int verificationCode,
+                     Card *card = nullptr);
   /**
    * @brief get the GPS location of the box
    * @return: Labeled_GPS object representing the GPS location of the box

--- a/src/Core/utils.cpp
+++ b/src/Core/utils.cpp
@@ -1,0 +1,19 @@
+#include "utils.h"
+
+long long Utils::pow(long long base, int exp, long long mod) {
+  long long result = 1;
+  for (; exp; exp >>= 1, base = (base * base) % mod) {
+    if (exp & 1) {
+      result = (result * base) % mod;
+    }
+  }
+  return result;
+}
+
+int Utils::generateVerificationCode(long long secret, int timestamp) {
+  constexpr long long MOD = 998244353; // A large prime number for modulus
+  constexpr int timeStep =
+      30; // Time step in seconds for verification code generation
+  return pow(secret, timestamp / timeStep, MOD) %
+         1000000; // Generate a 6-digit code
+}

--- a/src/Core/utils.h
+++ b/src/Core/utils.h
@@ -1,0 +1,22 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+namespace Utils {
+/**
+ * @brief calculate pow of a number
+ * @param base: the base number
+ * @param exp: the exponent
+ * @param mod: the modulus (optional)
+ * @return the result of base^exp
+ */
+long long pow(long long base, int exp, long long mod);
+/**
+ * @brief Generate a verification code based on the secret and timestamp
+ * @param secret: Secret key for the verification code generation
+ * @param timestamp: Current timestamp
+ * @return Generated verification code as an integer
+ */
+int generateVerificationCode(long long secret, int timestamp);
+} // namespace Utils
+
+#endif // UTILS_H

--- a/src/EmailServer.cpp
+++ b/src/EmailServer.cpp
@@ -1,4 +1,5 @@
 #include "EmailServer.h"
+#include "Env.h"
 using namespace std;
 
 EmailServer::EmailServer() : nextId(0) {}
@@ -70,6 +71,7 @@ EmailError EmailServer::sendEmail(const Email &email, const string &passwd) {
   // Create a new email object
   long long emailId = emailIdCounter[participantId]++;
   Email *newEmail = new Email(email);
+  newEmail->time = Env::getNow(); // Set the current time
 
   // Store the email in the sender's email map
   emails[participantId][emailId] = newEmail;

--- a/src/EmailServer.h
+++ b/src/EmailServer.h
@@ -1,6 +1,7 @@
 #ifndef EMAIL_SERVER_H
 #define EMAIL_SERVER_H
 
+#include "Core/JvTime.h"
 #include <map>
 #include <set>
 #include <string>
@@ -17,10 +18,16 @@ enum EmailError {
 };
 
 struct Email {
+  // For human readability
   std::string subject;
   std::string body;
+  // For object and human
   std::string sender;
-  std::string recipient; // Set of recipient email addresses
+  std::string recipient;
+  JvTime time; // Time when the email was sent
+  // For object
+  int verificationCode = -1;
+  std::string cardId = ""; // Card ID if applicable
 };
 
 class EmailServer {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -2,7 +2,9 @@
 #include "Core/Labeled_GPS.h"
 #include "EmailServer.h"
 #include "Env.h"
+#include <random>
 #include <string>
+#include <time.h>
 using namespace std;
 
 Server::Server(const string &serverAddress, const string &serverEmailPasswd,
@@ -13,8 +15,8 @@ Server::Server(const string &serverAddress, const string &serverEmailPasswd,
 }
 Server::~Server() {}
 
-void Server::notifyUser(long long id, const string &subject,
-                        const string &body) const {
+void Server::notifyUser(long long id, const string &subject, const string &body,
+                        const string &cardId, int verificationCode) const {
   if (auto it = userInfo.find(id); it != userInfo.end()) {
     string userAddr = it->second.email;
     Email email;
@@ -22,6 +24,8 @@ void Server::notifyUser(long long id, const string &subject,
     email.body = body;
     email.sender = address;
     email.recipient = userAddr;
+    email.cardId = cardId; // Set the card ID if applicable
+    email.verificationCode = verificationCode;
     emailServer->sendEmail(email, emailPasswd);
   }
 }
@@ -71,6 +75,11 @@ bool Server::addCard(const string &username, const string &passwd,
 
 bool Server::notifyCardFound(const string &cardId, const Labeled_GPS &gps,
                              const string &username, int reward) {
+  static bool seeded = false;
+  if (!seeded) {
+    srand(time(nullptr)); // Seed the random number generator
+    seeded = true;
+  }
 
   // Check if the card ID exists in the mapping
   auto it = cardOwnerId.find(cardId);
@@ -98,14 +107,23 @@ bool Server::notifyCardFound(const string &cardId, const Labeled_GPS &gps,
                 " has been found at location: " + gps.label + "( " +
                 to_string(gps.latitude) + ", " + to_string(gps.longitude) +
                 " )."; // Create notification body with GPS info"
-  notifyUser(ownerId, "Your Card is Found",
-             body); // Notify the owner of the card
+  // Notify the owner of the card
+  if (userInfo[ownerId].verificationType == UserInfo::EMAIL) {
+    // Generate a random verification code
+    int verificationCode = rand() % 1000000; // Random 6-digit code
+    body += "\nVerification Code: " + to_string(verificationCode) +
+            ". Please use this code to verify the card retrieval.";
+    findInfo.verificationCode = verificationCode; // Set verification code
+    notifyUser(ownerId, "Your Card is Found", body, cardId, verificationCode);
+  } else {
+    notifyUser(ownerId, "Your Card is Found", body, cardId);
+  }
 
   cardFindInfo[cardId] = findInfo;
   return true; // Notification sent successfully
 }
 
-bool Server::notifyCardRetrieved(const string &cardId) {
+bool Server::notifyCardRetrieved(const string &cardId, int verificationCode) {
   // Check if the card ID exists in the mapping
   auto findIt = cardFindInfo.find(cardId);
   if (findIt == cardFindInfo.end()) {
@@ -115,8 +133,14 @@ bool Server::notifyCardRetrieved(const string &cardId) {
   // Get the find info for the card
   FindInfo &findInfo = findIt->second;
 
+  long long ownerId = cardOwnerId[cardId];
+  if (userInfo[ownerId].verificationType == UserInfo::EMAIL &&
+      findInfo.verificationCode != verificationCode) {
+    return false; // Verification code does not match
+  }
+
   // Notify the owner of the card
-  notifyUser(cardOwnerId[cardId], "Your Card is Retrieved",
+  notifyUser(ownerId, "Your Card is Retrieved",
              "Your card with ID " + cardId + " has been retrieved.");
   if (findInfo.finderId != -1) {
     // Notify the finder of the card if they are registered

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -15,8 +15,8 @@ Server::~Server() {}
 
 void Server::notifyUser(long long id, const string &subject,
                         const string &body) const {
-  if (auto it = emailAddr.find(id); it != emailAddr.end()) {
-    string userAddr = it->second;
+  if (auto it = userInfo.find(id); it != userInfo.end()) {
+    string userAddr = it->second.email;
     Email email;
     email.subject = subject;
     email.body = body;
@@ -33,8 +33,8 @@ bool Server::addUser(const string &username, const string &passwd,
   }
   long long id = nextId++;
   userId[username] = id;
-  this->passwd[id] = passwd;
-  this->emailAddr[id] = emailAddr;
+  this->userInfo[id].passwd = passwd;
+  this->userInfo[id].email = emailAddr;
   return true; // User added successfully
 }
 
@@ -45,9 +45,8 @@ bool Server::removeUser(const string &username, const string &passwd) {
   auto it = userId.find(username);
   long long id = userId[username];
   userId.erase(it);
-  this->passwd.erase(id);
-  emailAddr.erase(id); // Remove email address mapping
-  return true;         // User removed successfully
+  this->userInfo.erase(id);
+  return true; // User removed successfully
 }
 
 bool Server::checkUser(const string &username, const string &passwd) const {
@@ -56,8 +55,8 @@ bool Server::checkUser(const string &username, const string &passwd) const {
     return false; // Username not found
   }
   long long id = it->second;
-  auto passwdIt = this->passwd.find(id);
-  return passwdIt != this->passwd.end() && passwdIt->second == passwd;
+  auto userIt = this->userInfo.find(id);
+  return userIt != this->userInfo.end() && userIt->second.passwd == passwd;
 }
 
 bool Server::addCard(const string &username, const string &passwd,

--- a/src/Server.h
+++ b/src/Server.h
@@ -9,15 +9,21 @@
 class EmailServer;
 
 struct FindInfo {
-  JvTime time;             // Time when the card was found
-  Labeled_GPS gps;         // GPS location where the card was found
-  long long finderId = -1; // ID of the user who found the card
-  int reward = 0;          // Reward for finding the card
+  JvTime time;               // Time when the card was found
+  Labeled_GPS gps;           // GPS location where the card was found
+  long long finderId = -1;   // ID of the user who found the card
+  int reward = 0;            // Reward for finding the card
+  int verificationCode = -1; // Verification code for the finder
 };
 
 struct UserInfo {
-  std::string passwd; // Password of the user
-  std::string email;  // Email address of the user
+  enum VerificationType : uint8_t {
+    EMAIL, // Email verification
+    APP,   // App 2FA verification
+  };
+  std::string passwd;                        // Password of the user
+  std::string email;                         // Email address of the user
+  VerificationType verificationType = EMAIL; // Type of verification used
 };
 
 class Server {
@@ -45,9 +51,13 @@ private:
    * @param id: the id of the user
    * @param subject: the subject of the email
    * @param body: the body to be sent to the user
+   * @param cardId: the card ID if applicable, "" if not
+   * @param verificationCode: the verification code to be sent to the user
    */
+  // TODO: make arguments shorter
   void notifyUser(long long id, const std::string &subject,
-                  const std::string &body) const;
+                  const std::string &body, const std::string &cardId = "",
+                  int verificationCode = -1) const;
 
 protected:
 public:
@@ -103,9 +113,10 @@ public:
   /**
    * @brief notify server a card is retrieved
    * @param id: the ID of card
+   * @param verificationCode: the verification code for the card retrieval
    * @return true if the process is successful, false if error occurs
    */
-  bool notifyCardRetrieved(const std::string &id);
+  bool notifyCardRetrieved(const std::string &id, int verificationCode);
 
   /**
    * @brief Get the find info of a card

--- a/src/Server.h
+++ b/src/Server.h
@@ -24,6 +24,7 @@ struct UserInfo {
   std::string passwd;                        // Password of the user
   std::string email;                         // Email address of the user
   VerificationType verificationType = EMAIL; // Type of verification used
+  long long id = -1;                         // User ID, -1 if not set
 };
 
 class Server {
@@ -38,6 +39,7 @@ private:
   std::map<std::string, long long> cardOwnerId;
   // card id -> find info mapping
   std::map<std::string, FindInfo> cardFindInfo;
+  std::vector<long long> secret2FA; // Verification codes for cards
   // Server's email address
   std::string address;
   // Server's email password
@@ -90,6 +92,17 @@ public:
    * @return true if the username and password match, false otherwise
    */
   bool checkUser(const std::string &username, const std::string &passwd) const;
+  /**
+   * @brief Set the verification type for a user
+   * @param username: the username of the user
+   * @param passwd: the password of the user
+   * @param type: the verification type to be set
+   * @return true if the verification type is set successfully, false if the
+   * user does not exist or the password does not match
+   */
+  bool setVerificationType(const std::string &username,
+                           const std::string &passwd,
+                           UserInfo::VerificationType type);
 
   /**
    * @brief Add a card to the server
@@ -140,6 +153,13 @@ public:
    */
   int redeemReward(const std::string &username, const std::string &password,
                    int amount);
+  /**
+   * @brief Setup 2FA
+   * @param username: the username of the user
+   * @return pair<id, secret> where id is the id for the 2FA and secret is the
+   * secret key, otherwise pair(-1, -1) if error occurs
+   */
+  std::pair<long long, long long> setup2FA(const std::string &username);
 };
 
 #endif // SERVER_H

--- a/src/Server.h
+++ b/src/Server.h
@@ -15,14 +15,17 @@ struct FindInfo {
   int reward = 0;          // Reward for finding the card
 };
 
+struct UserInfo {
+  std::string passwd; // Password of the user
+  std::string email;  // Email address of the user
+};
+
 class Server {
 private:
   // username -> user id mapping
   std::map<std::string, long long> userId;
-  // user id -> password mapping
-  std::map<long long, std::string> passwd;
-  // user id -> email address mapping
-  std::map<long long, std::string> emailAddr;
+  // user id -> user info mapping
+  std::map<long long, UserInfo> userInfo;
   // user id -> reward balance mapping
   std::map<long long, long long> rewardBalance;
   // card id -> owner id mapping

--- a/src/User.h
+++ b/src/User.h
@@ -10,6 +10,7 @@
 class Card;
 class Box;
 class EmailServer;
+class App2FA;
 
 class User : public Core {
 private:
@@ -23,7 +24,8 @@ private:
   EmailServer *emailServer; // Pointer to the email server for communication
   Server *server;           // Pointer to the server for user management
   UserInfo::VerificationType verificationType =
-      UserInfo::EMAIL; // Type of verification used
+      UserInfo::EMAIL;      // Type of verification used
+  App2FA *app2FA = nullptr; // Pointer to the App 2FA instance for verification
 protected:
 public:
   User(Server *server, const std::string &username, const std::string &passwd,
@@ -112,6 +114,12 @@ public:
    * @brief get all email IDs associated with the user
    */
   std::set<long long> getEmailIds() const;
+
+  /**
+   * @brief Set the verification type for the user
+   * @param type: the verification type to be set
+   */
+  void setVerificationType(UserInfo::VerificationType type);
 
   virtual Json::Value *dump2JSON(void) const override;
   virtual void JSON2Object(Json::Value *arg_json_ptr) override;

--- a/src/User.h
+++ b/src/User.h
@@ -2,6 +2,7 @@
 #define USER_H
 
 #include "Core/Core.h"
+#include "Server.h"
 #include <map>
 #include <set>
 #include <string>
@@ -9,7 +10,6 @@
 class Card;
 class Box;
 class EmailServer;
-class Server;
 
 class User : public Core {
 private:
@@ -18,9 +18,12 @@ private:
   std::string passwd; // Password for the user
   std::string email;
   std::map<std::string, Card *> cards; // id -> card owned by the user
+  std::map<std::string, int>
+      verificationCodes;    // id -> verification code for the card
   EmailServer *emailServer; // Pointer to the email server for communication
   Server *server;           // Pointer to the server for user management
-
+  UserInfo::VerificationType verificationType =
+      UserInfo::EMAIL; // Type of verification used
 protected:
 public:
   User(Server *server, const std::string &username, const std::string &passwd,
@@ -104,7 +107,7 @@ public:
    * @brief read the mail by index
    * @param index: the index of the mail to be read
    */
-  void readMail(int index) const;
+  void readMail(int index);
   /**
    * @brief get all email IDs associated with the user
    */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,8 @@ int main() {
   User tobiichi3227{&server, &emailServer, &scenarioJson["tobiichi3227"]};
   Box box1{&server, &scenarioJson["box1"]};
 
+  yushiuan9499.setVerificationType(UserInfo::APP);
+
   // Add the card to the server
   yushiuan9499.addCardToServer(string("31415926535"));
 


### PR DESCRIPTION
## Description
In this PR, I add two methods to verify the authenticity of a user.
- Email: The server will send a verification code to the user via email when notifying them their cards are found. 
  When the user wants to retrieve their card, they are required to enter the verification code, and the box sends a request to server to check the authenticity of this retrieval.
- 2FA: The user needs to sync the secret between their app and the server. 
  When the user want to retrieve their card, they must generate a verification code for the current time via the app, and the server also generate a verification code for the current time. 
  If the code are match, meaning the retrieval is considered authentic.

## Related Issue
Close #4 